### PR TITLE
Change authorizer to a map

### DIFF
--- a/events/apigw.go
+++ b/events/apigw.go
@@ -83,7 +83,7 @@ type APIGatewayWebsocketProxyRequestContext struct {
 	RequestID          string                    `json:"requestId"`
 	Identity           APIGatewayRequestIdentity `json:"identity"`
 	ResourcePath       string                    `json:"resourcePath"`
-	Authorizer         string                    `json:"authorizer"`
+	Authorizer         map[string]interface{}    `json:"authorizer"`
 	HTTPMethod         string                    `json:"httpMethod"`
 	APIID              string                    `json:"apiId"` // The API Gateway rest API Id
 	ConnectedAt        int64                     `json:"connectedAt"`

--- a/events/testdata/apigw-websocket-request.json
+++ b/events/testdata/apigw-websocket-request.json
@@ -81,7 +81,11 @@
       "user": "theUser"
     },
     "resourcePath": "/{proxy+}",
-    "authorizer": "*",
+    "authorizer": {
+      "principalId": "admin",
+      "clientId": 1,
+      "clientName": "Exata"
+    },
     "httpMethod": "POST",
     "apiId": "gy415nuibc",
     "connectedAt": 1547230720092,


### PR DESCRIPTION
Based on the observation from @Dasio and considering the possibility that if there is an inconsistency, AWS will fix that in line with the well established API Gateway's REST interface. Also it is a pain to decode into JSON (from golang, at least), if that is the inconsistency is not resolved.

Fixes suggestions from pr: aws/aws-lambda-go#159 ( issue: aws/aws-lambda-go#154 )